### PR TITLE
Restrict LinearLayout to not obscure status

### DIFF
--- a/app/src/main/res/layout/item_book.xml
+++ b/app/src/main/res/layout/item_book.xml
@@ -14,32 +14,30 @@
         android:id="@+id/book_cover"/>
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="280dp"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="16dp"
         android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
         android:orientation="vertical">
 
         <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textStyle="bold"
             android:id="@+id/book_title"
-            android:textSize="20sp"/>
-
-        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="16sp"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <TextView
             android:id="@+id/book_author"
-            />
-
-        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="16sp"
+            android:textSize="16sp" />
+
+        <TextView
             android:id="@+id/book_isbn"
-            />
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp" />
 
     </LinearLayout>
 


### PR DESCRIPTION
A quick and dirty fix for dealing with long titles obscuring the status of the book list item.