### PR TITLE
Reformat item_book to Prevent Overlap

### DIFF
--- a/app/src/main/java/ca/ualberta/CMPUT3012019T02/alexandria/model/holder/BookViewHolder.java
+++ b/app/src/main/java/ca/ualberta/CMPUT3012019T02/alexandria/model/holder/BookViewHolder.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import ca.ualberta.CMPUT3012019T02.alexandria.R;
@@ -19,7 +19,7 @@ public class BookViewHolder extends RecyclerView.ViewHolder{
     /**
      * The Item book.
      */
-    public LinearLayout itemBook;
+    public RelativeLayout itemBook;
     /**
      * The ImageView cover.
      */
@@ -50,10 +50,10 @@ public class BookViewHolder extends RecyclerView.ViewHolder{
         super(itemView);
 
         itemBook = itemView.findViewById(R.id.item_book);
-        ivCover = itemView.findViewById(R.id.book_cover);
-        tvTitle = itemView.findViewById(R.id.book_title);
-        tvAuthor = itemView.findViewById(R.id.book_author);
-        tvISBN = itemView.findViewById(R.id.book_isbn);
-        ivStatus = itemView.findViewById(R.id.book_status);
+        ivCover = itemView.findViewById(R.id.item_book_cover);
+        tvTitle = itemView.findViewById(R.id.item_book_title);
+        tvAuthor = itemView.findViewById(R.id.item_book_author);
+        tvISBN = itemView.findViewById(R.id.item_book_isbn);
+        ivStatus = itemView.findViewById(R.id.item_book_status);
     }
 }

--- a/app/src/main/res/layout/item_book.xml
+++ b/app/src/main/res/layout/item_book.xml
@@ -1,59 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="horizontal" android:layout_width="match_parent"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="8dp"
     android:background="@drawable/border_item_book"
     android:id="@+id/item_book">
 
     <ImageView
+        android:id="@+id/item_book_cover"
         android:layout_width="48dp"
         android:layout_height="72dp"
-        android:layout_marginLeft="8dp"
-        android:layout_marginStart="8dp"
-        android:id="@+id/book_cover"/>
+        android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
+        android:layout_centerVertical="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp" />
 
     <LinearLayout
-        android:layout_width="280dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginLeft="16dp"
+        android:id="@+id/item_book_text"
+        android:layout_width="275dp"
+        android:layout_height="72dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_toStartOf="@+id/item_book_status"
+        android:layout_toLeftOf="@+id/item_book_status"
+        android:layout_toEndOf="@+id/item_book_cover"
+        android:layout_toRightOf="@+id/item_book_cover"
         android:orientation="vertical">
 
         <TextView
-            android:id="@+id/book_title"
-            android:layout_width="wrap_content"
+            android:id="@+id/item_book_title"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="20sp"
+            android:layout_gravity="top"
+            android:textSize="16sp"
             android:textStyle="bold" />
 
         <TextView
-            android:id="@+id/book_author"
-            android:layout_width="wrap_content"
+            android:id="@+id/item_book_author"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="16sp" />
+            android:layout_gravity="center_vertical"
+            android:textSize="12sp" />
 
         <TextView
-            android:id="@+id/book_isbn"
-            android:layout_width="wrap_content"
+            android:id="@+id/item_book_isbn"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="16sp" />
+            android:layout_gravity="bottom"
+            android:textSize="12sp" />
 
     </LinearLayout>
 
-    <LinearLayout
-        android:gravity="end"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
 
-        <ImageView
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_gravity="center_vertical"
-            android:id="@+id/book_status"
-            android:layout_marginEnd="8dp"
-            android:layout_marginRight="8dp"/>
+    <ImageView
+        android:id="@+id/item_book_status"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:layout_gravity="center_vertical"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp" />
 
-    </LinearLayout>
 
-</LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
Android doesn't have flex box unfortunately so I can't justify content to make the text spread out vertically however.

![Screenshot_2019-03-13-01-50-32](https://user-images.githubusercontent.com/35116578/54262149-1d602680-4533-11e9-9dc8-d8bf88dc3867.png)
